### PR TITLE
bs - PUT for UCSBOrganization table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -96,4 +96,32 @@ public class UCSBOrganizationsController extends ApiController {
 
         return organization;
     }
+
+     /**
+     * Update a single organization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param code code of the organization
+     * @param incoming the new organization contents
+     * @return the updated organization object
+     */
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="code") @RequestParam String code,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(code)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, code));
+
+
+        organization.setOrgCode(incoming.getOrgCode());  
+        organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        organization.setOrgTranslation(incoming.getOrgTranslation());
+        organization.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -1,0 +1,83 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+/**
+ * This is a REST controller for UCSBOrganizations
+ */
+
+@Tag(name = "UCSBOrganizations")
+@RequestMapping("/api/ucsborganizations")
+@RestController
+@Slf4j
+
+public class UCSBOrganizationsController extends ApiController {
+
+    
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    /**
+     * This method returns a list of all ucsborganizations.
+     * @return a list of all ucsborganizations
+     */
+
+    @Operation(summary = "List all UCSB Organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allUCSBOrganizations() {
+        Iterable<UCSBOrganization> ucsbOrganizations = ucsbOrganizationRepository.findAll();
+        return ucsbOrganizations;
+    }
+
+    /**
+     * This method creates a new ucsborganization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode code of the organization
+     * @param orgTranslationShort shortened translation of the organization
+     * @param orgTranslation full translation of the organization
+     * @param inactive whether or not the organization is inactive
+     * @return the saved ucsborganization
+     */
+    @Operation(summary= "Create a new ucsborganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganizations(
+        @Parameter(name="orgCode") @RequestParam String orgCode,
+        @Parameter(name="orgTranslationShort") @RequestParam String orgTranslationShort,
+        @Parameter(name="orgTranslation") @RequestParam String orgTranslation,
+        @Parameter(name="inactive") @RequestParam boolean inactive 
+        )
+        {
+
+        UCSBOrganization ucsbOrganization = new UCSBOrganization();
+        ucsbOrganization.setOrgCode(orgCode);
+        ucsbOrganization.setOrgTranslationShort(orgTranslationShort);
+        ucsbOrganization.setOrgTranslation(orgTranslation);
+        ucsbOrganization.setInactive(inactive);
+
+        UCSBOrganization savedUCSBOrganization = ucsbOrganizationRepository.save(ucsbOrganization);
+
+        return savedUCSBOrganization;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -80,4 +80,20 @@ public class UCSBOrganizationsController extends ApiController {
 
         return savedUCSBOrganization;
     }
+
+    /**
+     * This method returns a single ucsborganization.
+     * @param code code of the ucsborganization
+     * @return a single ucsborganization
+     */
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="code") @RequestParam String code) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(code)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, code));
+
+        return organization;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 
+ * This is a JPA entity that represents a UCSBOrganization
+ * 
+ * A UCSBOrganization is an organization at UCSB
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganizations")
+public class UCSBOrganization {
+  @Id
+  private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBOrganizationRepository is a repository for UCSBOrganization entities
+ */
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+ 
+}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,68 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBOrganization-1",
+          "author": "bensoo777",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATIONS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBORGANIZATIONS_PK"
+                      },
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ORG_TRANSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }]
+                ,
+                "tableName": "UCSBORGANIZATIONS"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -125,5 +125,30 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
             assertEquals(expectedJson, responseString);
     }
 
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_organization_with_inactive_true() throws Exception {
+        // arrange
+        UCSBOrganization organization1 = UCSBOrganization.builder()
+                        .orgCode("zpr")
+                        .orgTranslationShort("Zeta Phi Rho")
+                        .orgTranslation("Zeta Phi Rho")
+                        .inactive(true)
+                        .build();
+
+        when(ucsbOrganizationRepository.save(eq(organization1))).thenReturn(organization1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        post("/api/ucsborganizations/post?orgCode=zpr&orgTranslationShort=Zeta Phi Rho&orgTranslation=Zeta Phi Rho&inactive=true")
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).save(eq(organization1));
+        String expectedJson = mapper.writeValueAsString(organization1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -1,0 +1,129 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationsController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationsControllerTests extends ControllerTestCase {
+    
+    @MockBean
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganizations/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganizations/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsborganizations/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsborganizations/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+            // arrange
+
+            UCSBOrganization organization1 = UCSBOrganization.builder()
+                .orgCode("zpr")
+                .orgTranslationShort("Zeta Phi Rho")
+                .orgTranslation("Zeta Phi Rho")
+                .inactive(false)
+                .build();
+
+            ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+            expectedOrganizations.add(organization1);
+
+            when(ucsbOrganizationRepository .findAll()).thenReturn(expectedOrganizations);
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganizations/all"))
+                            .andExpect(status().isOk()).andReturn();
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_organization() throws Exception {
+            // arrange
+
+            UCSBOrganization organization1 = UCSBOrganization.builder()
+                            .orgCode("zpr")
+                            .orgTranslationShort("Zeta Phi Rho")
+                            .orgTranslation("Zeta Phi Rho")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.save(eq(organization1))).thenReturn(organization1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/ucsborganizations/post?orgCode=zpr&orgTranslationShort=Zeta Phi Rho&orgTranslation=Zeta Phi Rho&inactive=false")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).save(eq(organization1));
+            String expectedJson = mapper.writeValueAsString(organization1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+
+}


### PR DESCRIPTION
Closes #17 

In this PR, we add the PUT operation to the UCSBOrganizationsController, so that we will be able to edit existing organizations. 

<img width="573" alt="Screenshot 2025-04-25 at 4 08 15 PM" src="https://github.com/user-attachments/assets/3c36f38d-2f3b-43c1-9fc7-d50468028bd1" />
