### PR TITLE
Mz - put for helprequest table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
       <version>4.29.2</version>
     </dependency>
 
+  
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.0.pr1</version>
+    </dependency>
   </dependencies>
 
   <!-- (24) <repositories/> -->

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -1,0 +1,98 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for HelpRequests
+ */
+
+@Tag(name = "HelpRequests")
+@RequestMapping("/api/helprequests")
+@RestController
+@Slf4j
+public class HelpRequestsController extends ApiController{
+    
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+        /**
+     * List all HelpRequests
+     * 
+     * @return an iterable of HelpRequests
+     */
+
+    @Operation(summary= "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allUCSBDates() {
+        Iterable<HelpRequest> dates = helpRequestRepository.findAll();
+        return dates;
+    }
+
+    /**
+     * Create a new HelpRequest
+     * 
+     * @param requesterEmail        the email of the requester
+     * @param teamId                 the team ID
+     * @param tableOrBreakoutRoom    the table or breakout room
+     * @param requestTime            the request time (ISO format)
+     * @param explanation            the explanation of the help request
+     * @param solved                 whether the request is solved
+     * @return the saved HelpRequest
+     */
+
+    @Operation(summary = "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="teamId") @RequestParam String teamId,
+            @Parameter(name="tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name="requestTime", description="Request time (ISO format, e.g., YYYY-MM-DDTHH:MM:SS)") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="solved") @RequestParam boolean solved)
+            throws JsonProcessingException {
+
+        log.info("requestTime={}", requestTime);
+
+        HelpRequest helpRequest = HelpRequest.builder()
+                .requesterEmail(requesterEmail)
+                .teamId(teamId)
+                .tableOrBreakoutRoom(tableOrBreakoutRoom)
+                .requestTime(requestTime)
+                .explanation(explanation)
+                .solved(solved)
+                .build();
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+}
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -111,6 +111,36 @@ public class HelpRequestsController extends ApiController{
 
         return helpRequest;
     }
+
+    /**
+     * Update a single help request
+     * 
+     * @param id       id of the help request to update
+     * @param incoming the new help request
+     * @return the updated help request object
+     */
+    @Operation(summary = "Update a single help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public HelpRequest updateHelpRequest(
+            @Parameter(name = "id") @RequestParam Long id,
+            @RequestBody @Valid HelpRequest incoming) {
+
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequest.setRequesterEmail(incoming.getRequesterEmail());
+        helpRequest.setTeamId(incoming.getTeamId());
+        helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+        helpRequest.setRequestTime(incoming.getRequestTime());
+        helpRequest.setExplanation(incoming.getExplanation());
+        helpRequest.setSolved(incoming.getSolved());
+
+        helpRequestRepository.save(helpRequest);
+
+        return helpRequest;
+    }
+
 }
 
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
@@ -92,6 +93,23 @@ public class HelpRequestsController extends ApiController{
         HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
 
         return savedHelpRequest;
+    }
+
+    /**
+     * Get a single help request by id
+     * 
+     * @param id the id of the help request
+     * @return a HelpRequest
+     */
+    @Operation(summary = "Get a single help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        return helpRequest;
     }
 }
 

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a HelpRequest, i.e. an entry
+ * that comes from the UCSB API for academic calendar dates.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id; // consequtive integers
+
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDateRepository is a repository for UCSBDate entities.
+ */
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/HelpRequests.json
+++ b/src/main/resources/db/migration/changes/HelpRequests.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "HelpRequests-1",
+          "author": "matthewzhang275",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "HelpRequests"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "name": "id",
+                      "type": "BIGINT",
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "HelpRequests_PK"
+                      }
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "requester_email",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "team_id",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "table_or_breakout_room",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "request_time",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "explanation",
+                      "type": "VARCHAR(1000)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "solved",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "HELPREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -1,0 +1,137 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestsController.class)
+@Import(TestConfig.class)
+public class HelpRequestsControllerTests extends ControllerTestCase {
+    @MockBean
+    HelpRequestRepository helpRequestRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/helprequests/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/helprequests/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/helprequests/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/helprequests/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+        LocalDateTime ldt1 = LocalDateTime.parse("2025-03-11T00:00:00");
+
+        HelpRequest helpRequest1 = HelpRequest.builder()
+        .requesterEmail("jane@ucsb.edu")
+        .teamId("T123")
+        .tableOrBreakoutRoom("Room 5B")
+        .requestTime(ldt1)
+        .explanation("Need help debugging SQL error")
+        .solved(false)
+        .build();
+
+        ArrayList<HelpRequest> expectedHelpRequests = new ArrayList<>();
+        expectedHelpRequests.add(helpRequest1);
+
+        when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequests);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/helprequests/all"))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(helpRequestRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedHelpRequests);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+        // arrange
+        LocalDateTime ldt1 = LocalDateTime.parse("2025-04-25T21:30:00");
+
+        HelpRequest helpRequest1 = HelpRequest.builder()
+                .requesterEmail("jane@ucsb.edu")
+                .teamId("T123")
+                .tableOrBreakoutRoom("Room 5B")
+                .requestTime(ldt1)
+                .explanation("Need help debugging SQL error")
+                .solved(false)
+                .build();
+
+        when(helpRequestRepository.save(any(HelpRequest.class))).thenReturn(helpRequest1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        post("/api/helprequests/post?requesterEmail=jane@ucsb.edu&teamId=T123&tableOrBreakoutRoom=Room%205B&requestTime=2025-04-25T21:30:00&explanation=Need%20help%20debugging%20SQL%20error&solved=false")
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        verify(helpRequestRepository, times(1)).save(any(HelpRequest.class));
+        String expectedJson = mapper.writeValueAsString(helpRequest1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -134,4 +134,64 @@ public class HelpRequestsControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
         }
+
+        // SECOND
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-25T21:30:00");
+
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                .requesterEmail("jane@ucsb.edu")
+                .teamId("T123")
+                .tableOrBreakoutRoom("Room 5B")
+                .requestTime(ldt1)
+                .explanation("Need help debugging SQL error")
+                .solved(false)
+                .build();
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(helpRequest1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);                
+        }
+
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -194,4 +194,87 @@ public class HelpRequestsControllerTests extends ControllerTestCase {
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
         }
 
+        // PART 3
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_helprequest() throws Exception {
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2025-04-25T21:30:00");
+            LocalDateTime ldt2 = LocalDateTime.parse("2025-05-01T15:00:00");
+        
+            HelpRequest helpRequestOrig = HelpRequest.builder()
+                    .requesterEmail("jane@ucsb.edu")
+                    .teamId("T123")
+                    .tableOrBreakoutRoom("Room 5B")
+                    .requestTime(ldt1)
+                    .explanation("Need help debugging SQL error")
+                    .solved(false)
+                    .build();
+        
+            HelpRequest helpRequestEdited = HelpRequest.builder()
+                    .requesterEmail("jane@ucsb.edu")
+                    .teamId("T124")
+                    .tableOrBreakoutRoom("Room 6C")
+                    .requestTime(ldt2)
+                    .explanation("Updated explanation")
+                    .solved(true)
+                    .build();
+        
+            String requestBody = mapper.writeValueAsString(helpRequestEdited);
+        
+            when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.of(helpRequestOrig));
+        
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/helprequests?id=67")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .characterEncoding("utf-8")
+                                    .content(requestBody)
+                                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andReturn();
+        
+            // assert
+            verify(helpRequestRepository, times(1)).findById(67L);
+            verify(helpRequestRepository, times(1)).save(helpRequestOrig); // saving the modified original
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+        }
+        
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_helprequest_that_does_not_exist() throws Exception {
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2025-04-25T21:30:00");
+        
+            HelpRequest helpRequestEdited = HelpRequest.builder()
+                    .requesterEmail("jane@ucsb.edu")
+                    .teamId("T123")
+                    .tableOrBreakoutRoom("Room 5B")
+                    .requestTime(ldt1)
+                    .explanation("Need help debugging SQL error")
+                    .solved(false)
+                    .build();
+        
+            String requestBody = mapper.writeValueAsString(helpRequestEdited);
+        
+            when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+        
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/helprequests?id=67")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .characterEncoding("utf-8")
+                                    .content(requestBody)
+                                    .with(csrf()))
+                    .andExpect(status().isNotFound())
+                    .andReturn();
+        
+            // assert
+            verify(helpRequestRepository, times(1)).findById(67L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("HelpRequest with id 67 not found", json.get("message"));
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -213,7 +213,7 @@ public class HelpRequestsControllerTests extends ControllerTestCase {
                     .build();
         
             HelpRequest helpRequestEdited = HelpRequest.builder()
-                    .requesterEmail("jane@ucsb.edu")
+                    .requesterEmail("jane1@ucsb.edu")
                     .teamId("T124")
                     .tableOrBreakoutRoom("Room 6C")
                     .requestTime(ldt2)


### PR DESCRIPTION
Closes #35 
In this PR, we add the PUT operations to the HelpRequests Controller so that will be able to edit existing rows in the data table. 

<img width="1505" alt="Screenshot 2025-04-25 at 11 00 50 PM" src="https://github.com/user-attachments/assets/f2de47b5-2ed2-4d6b-abd7-91890e632769" />
<img width="1452" alt="Screenshot 2025-04-25 at 11 01 00 PM" src="https://github.com/user-attachments/assets/f616d546-e4f5-4c78-a046-c58848e21d4c" />
